### PR TITLE
Deal with more involved marker overlaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,12 @@ _Author's note: There is a tendency, when considering using Mobiledoc, to be con
 - Building documents programatically
 - Manipulation of documents, including markups and atoms
 
+## Development
+
+### Installation
+
+(With Ruby 3.2.x and `bundler` installed) run `bundler install`
+
+### Tests
+
+Run `rake test`

--- a/lib/mobiledoc/document.rb
+++ b/lib/mobiledoc/document.rb
@@ -27,6 +27,7 @@ module Mobiledoc
 
     private
 
+    # Ordering the markups means we have a stable output
     def ordered_markups
       markups.to_a.sort_by { |markup| markup.tag_name }
     end

--- a/lib/mobiledoc/sections/text.rb
+++ b/lib/mobiledoc/sections/text.rb
@@ -9,7 +9,22 @@ module Mobiledoc::Section
       @tag = options[:tag] || :p
     end
 
+    # Append adds text with optional markups to the end of the section. The
+    # order of the markups has an impact of where the final marker breaks
+    # will be. Once this supports edits, the application on markups there will
+    # also have an impact on marker placement
     def append(text, markups = [])
+      we want to hold a list of ranges here, so we can support edits later, but
+      also because it makes serialisation easier too
+
+      Might need to find and join ranges which match markups. Need to decide 
+      what the semanics are here re appending. Might be different to applying
+      to a range. Perhaps we should rejig the order to better line up with existing markups?
+
+      Is appending: adding text then applying markups to that range? A shorthand
+
+      OR perhaps this API is different from an 'editor' as it is programatic, rather than a UI?
+      So there _could_ be a "natural" order to the way markers are built
       segments << [text, markups] unless text.nil?
     end
 
@@ -37,6 +52,7 @@ module Mobiledoc::Section
 
         text = current_segment.first
         current_markups = current_segment.last.uniq
+        # @incomplete: I think we need to either run this loop backwards or run two passes (maybe a longest chain sorting)
         next_markups = next_segment&.last&.uniq || []
 
         # Ensure we only open markups that aren't already open
@@ -44,9 +60,13 @@ module Mobiledoc::Section
 
         markups_open_in_current_segment = open_markups + markups_to_open
         # Any markups that are already open, or have just been opened, that aren't in the next segment
+        # [underline, strikethrough]
+        # [strikethrough]
         markups_to_close = markups_open_in_current_segment - next_markups
 
-        markup_indexes_to_open = markups_to_open.map { |markup| ordered_markups.index(markup) }
+        markup_indexes_to_open = markups_to_open
+          .sort_by { |markup| [next_markups.include?(markup) ? 1 : 0, markup.tag_name] }
+          .map { |markup| ordered_markups.index(markup) }
         number_markups_closed = markups_to_close.length 
 
         # @magic: '0' is a text markup. Also it might be clearer if this was calling a

--- a/lib/mobiledoc/sections/text.rb
+++ b/lib/mobiledoc/sections/text.rb
@@ -1,4 +1,14 @@
 module Mobiledoc::Section
+
+  class Segment
+    attr_accessor :text, :markups
+
+    def initialize(text, markups = [])
+      @text = text
+      @markups = markups.uniq
+    end
+  end
+
   class Text
     attr_accessor :tag
 
@@ -25,11 +35,11 @@ module Mobiledoc::Section
 
       # OR perhaps this API is different from an 'editor' as it is programatic, rather than a UI?
       # So there _could_ be a "natural" order to the way markers are built
-      segments << [text, markups] unless text.nil?
+      segments << Segment.new(text, markups) unless text.nil?
     end
 
     def markups
-      Set.new segments.map { |segment| segment.last }.flatten
+      Set.new segments.map { |segment| segment.markups }.flatten
     end
 
     def serialise(ordered_markups)
@@ -50,10 +60,10 @@ module Mobiledoc::Section
         current_segment = segments[index]
         next_segment = segments[index + 1]
 
-        text = current_segment.first
-        current_markups = current_segment.last.uniq
+        text = current_segment.text
+        current_markups = current_segment.markups
         # @incomplete: I think we need to either run this loop backwards or run two passes (maybe a longest chain sorting)
-        next_markups = next_segment&.last&.uniq || []
+        next_markups = next_segment&.markups || []
 
         # Ensure we only open markups that aren't already open
         markups_to_open = current_markups - open_markups

--- a/lib/mobiledoc/sections/text.rb
+++ b/lib/mobiledoc/sections/text.rb
@@ -14,17 +14,17 @@ module Mobiledoc::Section
     # will be. Once this supports edits, the application on markups there will
     # also have an impact on marker placement
     def append(text, markups = [])
-      we want to hold a list of ranges here, so we can support edits later, but
-      also because it makes serialisation easier too
+      # we want to hold a list of ranges here, so we can support edits later, but
+      # also because it makes serialisation easier too
 
-      Might need to find and join ranges which match markups. Need to decide 
-      what the semanics are here re appending. Might be different to applying
-      to a range. Perhaps we should rejig the order to better line up with existing markups?
+      # Might need to find and join ranges which match markups. Need to decide 
+      # what the semanics are here re appending. Might be different to applying
+      # to a range. Perhaps we should rejig the order to better line up with existing markups?
 
-      Is appending: adding text then applying markups to that range? A shorthand
+      # Is appending: adding text then applying markups to that range? A shorthand
 
-      OR perhaps this API is different from an 'editor' as it is programatic, rather than a UI?
-      So there _could_ be a "natural" order to the way markers are built
+      # OR perhaps this API is different from an 'editor' as it is programatic, rather than a UI?
+      # So there _could_ be a "natural" order to the way markers are built
       segments << [text, markups] unless text.nil?
     end
 

--- a/lib/mobiledoc/sections/text.rb
+++ b/lib/mobiledoc/sections/text.rb
@@ -10,6 +10,8 @@ module Mobiledoc::Section
   end
 
   class Text
+    SECTION_ID = 0.freeze
+
     attr_accessor :tag
 
     def initialize(text = nil, options = {})
@@ -24,17 +26,6 @@ module Mobiledoc::Section
     # will be. Once this supports edits, the application on markups there will
     # also have an impact on marker placement
     def append(text, markups = [])
-      # we want to hold a list of ranges here, so we can support edits later, but
-      # also because it makes serialisation easier too
-
-      # Might need to find and join ranges which match markups. Need to decide 
-      # what the semanics are here re appending. Might be different to applying
-      # to a range. Perhaps we should rejig the order to better line up with existing markups?
-
-      # Is appending: adding text then applying markups to that range? A shorthand
-
-      # OR perhaps this API is different from an 'editor' as it is programatic, rather than a UI?
-      # So there _could_ be a "natural" order to the way markers are built
       segments << Segment.new(text, markups) unless text.nil?
     end
 
@@ -60,33 +51,52 @@ module Mobiledoc::Section
         current_segment = segments[index]
         next_segment = segments[index + 1]
 
-        text = current_segment.text
-        current_markups = current_segment.markups
-        # @incomplete: I think we need to either run this loop backwards or run two passes (maybe a longest chain sorting)
         next_markups = next_segment&.markups || []
 
         # Ensure we only open markups that aren't already open
-        markups_to_open = current_markups - open_markups
+        prev_partitions = partition_trunk(open_markups, current_segment.markups)
+        markups_already_open = prev_partitions[0]
+        # prev_partitions[1] should always be empty since no markups should be left open that aren't used in this segment
+        markups_to_open = prev_partitions[2]
+        markups_open_in_current_segment = markups_already_open + markups_to_open
 
-        markups_open_in_current_segment = open_markups + markups_to_open
         # Any markups that are already open, or have just been opened, that aren't in the next segment
-        # [underline, strikethrough]
-        # [strikethrough]
-        markups_to_close = markups_open_in_current_segment - next_markups
+        next_partitions = partition_trunk(markups_open_in_current_segment, next_markups)
+        markups_to_close = next_partitions[1]
 
-        markup_indexes_to_open = markups_to_open
-          .sort_by { |markup| [next_markups.include?(markup) ? 1 : 0, markup.tag_name] }
-          .map { |markup| ordered_markups.index(markup) }
+        # Get the document index of markups
+        markup_indexes_to_open = markups_to_open.map { |markup| ordered_markups.index(markup) }
         number_markups_closed = markups_to_close.length 
 
-        # @magic: '0' is a text markup. Also it might be clearer if this was calling a
-        # method to build this perhaps?
-        serialised << [0, markup_indexes_to_open, number_markups_closed, text]
+        serialised << [SECTION_ID, markup_indexes_to_open, number_markups_closed, current_segment.text]
 
         open_markups = markups_open_in_current_segment - markups_to_close
       end
 
       serialised
+    end
+
+    # Returns three arrays
+    # - first is the ordered union pinned to the start of the arrays
+    # - second is everything past the union from a
+    # - third is everything past the union from b
+    # e.g a: [1, 2, 3, 4, 5], b: [1, 2, 3, 6, 7, 8]
+    # returns [[1, 2, 3], [4, 5], [6, 7, 8]]
+    def partition_trunk(a, b)
+      partition_index = nil
+      for index in 0..(a.length-1) do
+        break if a[index] != b[index]
+        partition_index = index
+      end
+
+      # Handle non-overlap case
+      return [[], a, b] if partition_index.nil?
+
+      return [
+        a[0..partition_index],
+        a[partition_index+1..a.length],
+        b[partition_index+1..b.length],
+      ]
     end
   end
 end

--- a/spec/document/serialise_spec.rb
+++ b/spec/document/serialise_spec.rb
@@ -280,9 +280,9 @@ describe Document, 'serialise' do
               ['u']
             ]
             doc[:sections][0][2].must_equal [
-              [0, [1], 1, 'underline'],
-              [0, [0, 1], 1, ' now with strike through'],
-              [0, [], 1, ' but no more underline'],
+              [0, [1], 0, 'underline'],
+              [0, [0], 2, ' now with strike through,'],
+              [0, [0], 1, ' but no more underline'],
             ]
             doc[:atoms].must_equal []
             doc[:cards].must_equal []
@@ -305,10 +305,10 @@ describe Document, 'serialise' do
               ['u']
             ]
             doc[:sections][0][2].must_equal [
-              [0, [2], 0, 'underline'],
-              [0, [0], 2, 'bold and underline'],
-              [0, [0, 2], 1, 'bold and strike'],
-              [0, [], 1, 'strike']
+              [0, [2], 1, 'underline'],
+              [0, [0, 2], 1, 'bold and underline'],
+              [0, [1], 2, 'bold and strike'],
+              [0, [1], 1, 'strike']
             ]
             doc[:atoms].must_equal []
             doc[:cards].must_equal []
@@ -340,14 +340,14 @@ describe Document, 'serialise' do
               ['u']
             ]
             doc[:sections][0][2].must_equal [
-              [0, [0], 1, 'ONE '],
-              [0, [1, 0], 1, '_TWO'],
-              [0, [], 1, ' three_']
+              [0, [0], 0, 'ONE '],
+              [0, [1], 2, '_TWO'],
+              [0, [1], 1, ' three_']
             ]
             doc[:sections][1][2].must_equal [
-              [0, [0], 0, 'FOUR '],
-              [0, [1], 2, '_FIVE'],
-              [0, [1], 1, ' six_']
+              [0, [0], 1, 'FOUR '],
+              [0, [1, 0], 1, '_FIVE'],
+              [0, [], 1, ' six_']
             ]
             doc[:atoms].must_equal []
             doc[:cards].must_equal []

--- a/spec/document/serialise_spec.rb
+++ b/spec/document/serialise_spec.rb
@@ -322,9 +322,9 @@ describe Document, 'serialise' do
             [' three_', [Markup::Underline]]
           ]}
           let(:segments_two) {[
-            ['ONE ', [Markup::Bold]],
-            ['_TWO', [Markup::Underline, Markup::Bold]],
-            [' three_', [Markup::Underline]]
+            ['FOUR ', [Markup::Bold]],
+            ['_FIVE', [Markup::Underline, Markup::Bold]],
+            [' six_', [Markup::Underline]]
           ]}
           let(:section_two) do
             Section::Text.new.tap do |s|
@@ -340,14 +340,14 @@ describe Document, 'serialise' do
               ['u']
             ]
             doc[:sections][0][2].must_equal [
-              [0, [0], 0, 'ONE '],
-              [0, [1], 2, '_TWO'],
-              [0, [1], 1, ' three_']
-            ]
-            doc[:sections][1][2].must_equal [
               [0, [0], 1, 'ONE '],
               [0, [1, 0], 1, '_TWO'],
               [0, [], 1, ' three_']
+            ]
+            doc[:sections][1][2].must_equal [
+              [0, [0], 0, 'FOUR '],
+              [0, [1], 2, '_FIVE'],
+              [0, [1], 1, ' six_']
             ]
             doc[:atoms].must_equal []
             doc[:cards].must_equal []

--- a/spec/document/serialise_spec.rb
+++ b/spec/document/serialise_spec.rb
@@ -198,12 +198,12 @@ describe Document, 'serialise' do
           end
         end
 
-        describe 'partially overlapping' do
+        describe 'overlapping middle' do
           let(:segments_one) { [
             ['underline', [Markup::Underline]],
             [' ', [Markup::Underline]],
-            ['bold and underline', [Markup::Bold, Markup::Underline]],
-            ['.', [Markup::Underline]]
+            ['bold and underline', [Markup::Underline, Markup::Bold]],
+            ['.', [Markup::Underline]],
           ]}
 
           it 'referres to the correct index' do
@@ -216,7 +216,138 @@ describe Document, 'serialise' do
               [0, [1], 0, 'underline'],
               [0, [], 0, ' '],
               [0, [0], 1, 'bold and underline'],
-              [0, [], 1, '.']
+              [0, [], 1, '.'],
+            ]
+            doc[:atoms].must_equal []
+            doc[:cards].must_equal []
+          end
+        end
+
+        describe 'overlapping start' do
+          let(:segments_one) { [
+            ['underline and bold,', [Markup::Underline, Markup::Bold]],
+            [' just underline', [Markup::Underline]]
+          ]}
+
+          it 'referres to the correct index' do
+            doc = subject
+            # @incomplete: this order looks reversed
+            doc[:markups].must_equal [
+              ['b'],
+              ['u']
+            ]
+            doc[:sections][0][2].must_equal [
+              [0, [1, 0], 1, 'underline and bold,'],
+              [0, [], 1, ' just underline'],
+            ]
+            doc[:atoms].must_equal []
+            doc[:cards].must_equal []
+          end
+        end
+
+        describe 'overlapping end' do
+          let(:segments_one) { [
+            ['just underline,', [Markup::Underline]],
+            [' underline and bold,', [Markup::Underline, Markup::Bold]]
+          ]}
+
+          it 'referres to the correct index' do
+            doc = subject
+            doc[:markups].must_equal [
+              ['b'],
+              ['u']
+            ]
+            doc[:sections][0][2].must_equal [
+              [0, [1], 0, 'just underline,'],
+              [0, [0], 2, ' underline and bold,'],
+            ]
+            doc[:atoms].must_equal []
+            doc[:cards].must_equal []
+          end
+        end
+
+        describe 'partially overlapping' do
+          let(:segments_one) { [
+            ['underline', [Markup::Underline]],
+            [' now with strike through,', [Markup::Underline, Markup::StrikeThrough]],
+            [' but no more underline', [Markup::StrikeThrough]]
+          ]}
+
+          it 'referres to the correct index' do
+            doc = subject
+            doc[:markups].must_equal [
+              ['s'],
+              ['u']
+            ]
+            doc[:sections][0][2].must_equal [
+              [0, [1], 1, 'underline'],
+              [0, [0, 1], 1, ' now with strike through'],
+              [0, [], 1, ' but no more underline'],
+            ]
+            doc[:atoms].must_equal []
+            doc[:cards].must_equal []
+          end
+        end
+
+        describe 'overlapping two (straddle)' do
+          let(:segments_one) { [
+            ['underline', [Markup::Underline]],
+            ['bold and underline', [Markup::Bold, Markup::Underline]],
+            ['bold and strike', [Markup::Bold, Markup::StrikeThrough]],
+            ['strike', [Markup::StrikeThrough]]
+          ]}
+
+          it 'referres to the correct index' do
+            doc = subject
+            doc[:markups].must_equal [
+              ['b'],
+              ['s'],
+              ['u']
+            ]
+            doc[:sections][0][2].must_equal [
+              [0, [2], 0, 'underline'],
+              [0, [0], 2, 'bold and underline'],
+              [0, [0, 2], 1, 'bold and strike'],
+              [0, [], 1, 'strike']
+            ]
+            doc[:atoms].must_equal []
+            doc[:cards].must_equal []
+          end
+        end
+
+        describe 'segment breaking is order dependent' do
+          let(:segments_one) {[
+            ['ONE ', [Markup::Bold]],
+            ['_TWO', [Markup::Bold, Markup::Underline]],
+            [' three_', [Markup::Underline]]
+          ]}
+          let(:segments_two) {[
+            ['ONE ', [Markup::Bold]],
+            ['_TWO', [Markup::Underline, Markup::Bold]],
+            [' three_', [Markup::Underline]]
+          ]}
+          let(:section_two) do
+            Section::Text.new.tap do |s|
+              segments_two.each { |segment| s.append(*segment) }
+            end
+          end
+          subject { Document.new(sections: [section_one, section_two]).serialise }
+
+          it 'referres to the correct index' do
+            doc = subject
+            doc[:markups].must_equal [
+              ['b'],
+              ['u']
+            ]
+            doc[:sections][0][2].must_equal [
+              [0, [0], 0, 'ONE '],
+              [0, [1], 2, '_TWO'],
+              [0, [1], 1, ' three_']
+            ]
+            doc[:sections][1][2].must_equal [
+              [0, [0], 1, 'ONE '],
+              [0, [1, 0], 1, '_TWO'],
+              [0, [], 1, ' three_']
             ]
             doc[:atoms].must_equal []
             doc[:cards].must_equal []


### PR DESCRIPTION
Previously there was a more naive handling of the order of markups in adjacent segments, namely that it assumed every segment had the same ordering for markups. Markups can be ordered any which way so correctly* handling them is important. Some normalisation of markup order could be done further up in the stack (`append` perhaps) but this PR is only concerned with the serialisation

_* correct meaning as close to what I can figure [the canonical impl](https://bustle.github.io/mobiledoc-kit/demo/) does_